### PR TITLE
fix: resolve CRLF line endings and missing inference deps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Ensure shell scripts always use LF line endings
+*.sh text eol=lf
+*.py text eol=lf
+
+# Windows-safe defaults for other text files
+* text=auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 inference = [
     "grpcio>=1.60",
     "grpcio-tools>=1.60",
+    "grpcio-health-checking>=1.60",
 ]
 llm = ["openai>=1.0"]
 tts = ["openai>=1.0"]

--- a/scripts/inference.sh
+++ b/scripts/inference.sh
@@ -80,7 +80,7 @@ export OMP_NUM_THREADS=1
 export TORCH_CPP_LOG_LEVEL
 
 # ── torch.compile inductor cache (persists across restarts) ────────────────
-: "${TORCHINDUCTOR_CACHE_DIR:=/root/autodl-tmp/cache/torch_inductor}"
+: "${TORCHINDUCTOR_CACHE_DIR:=${HOME}/.cache/torch_inductor}"
 export TORCHINDUCTOR_FX_GRAPH_CACHE=1
 export TORCHINDUCTOR_CACHE_DIR
 mkdir -p "${TORCHINDUCTOR_CACHE_DIR}"


### PR DESCRIPTION
- Convert all scripts/\*.sh and scripts/\*.py from CRLF to LF
- Add .gitattributes to enforce LF for .sh and .py files
- Fix default TORCHINDUCTOR_CACHE_DIR from /root/... to $HOME/.cache/torch_inductor
- Add grpcio-health-checking to [inference] deps in pyproject.toml