### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ When you have GPU resources and want the Agent to be visible, enable avatar infe
 
 ### Plugin-Based Stack
 
-Brain, voice, hearing, tools, memory, and face are all replaceable modules. You can combine omni models, LLMs, TTS, ASR, embeddings, RAG, tool calls, and Avatar backends in `cyberverse_config.yaml`, then configure different vendors' API keys and service endpoints in the web UI at **`/settings`** to switch providers and model combinations by scenario.
+Brain, voice, hearing, tools, memory, and face are all replaceable modules. You can combine omni models, LLMs, TTS, ASR, embeddings, RAG, tool calls, and Avatar backends in `cyberverse_config.yaml`, then configure different vendors' API keys and service endpoints in the web UI at **`/settings`** to switch providers and model combinations by scenario. The [LiteLLM](https://github.com/BerriAI/litellm) plugin adds access to 100+ LLM providers (AWS Bedrock, Azure, Vertex AI, Mistral, Cohere, etc.) through a single unified interface.
 
 ## Quick Start
 

--- a/inference/plugins/llm/litellm_plugin.py
+++ b/inference/plugins/llm/litellm_plugin.py
@@ -1,0 +1,77 @@
+from typing import AsyncIterator
+
+from inference.core.types import LLMResponseChunk, PluginConfig
+from inference.plugins.llm.base import LLMPlugin
+from inference.plugins.llm.openai_plugin import SENTENCE_ENDERS
+
+
+class LiteLLMPlugin(LLMPlugin):
+    """LLM plugin using LiteLLM to access 100+ providers via a unified API."""
+
+    name = "llm.litellm"
+    supports_images = True
+
+    def __init__(self) -> None:
+        self.model = "gpt-4o"
+        self.temperature = 0.7
+        self.system_prompt = ""
+        self.api_key: str | None = None
+        self.api_base: str | None = None
+
+    async def initialize(self, config: PluginConfig) -> None:
+        self.model = config.params.get("model", "gpt-4o")
+        self.temperature = float(config.params.get("temperature", 0.7))
+        self.system_prompt = config.params.get("system_prompt", "")
+        self.api_key = config.params.get("api_key")
+        self.api_base = config.params.get("api_base") or config.params.get("base_url")
+
+    async def generate_stream(
+        self, messages: list[dict]
+    ) -> AsyncIterator[LLMResponseChunk]:
+        import litellm
+
+        full_messages = list(messages)
+        has_system = any(m.get("role") == "system" for m in full_messages)
+        if self.system_prompt and not has_system:
+            full_messages = [{"role": "system", "content": self.system_prompt}] + full_messages
+
+        kwargs: dict = {
+            "model": self.model,
+            "messages": full_messages,
+            "temperature": self.temperature,
+            "stream": True,
+            "drop_params": True,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+
+        accumulated = ""
+        response = await litellm.acompletion(**kwargs)
+        async for chunk in response:
+            choices = chunk.get("choices") or []
+            if not choices:
+                continue
+            delta = choices[0].get("delta") or {}
+            token = delta.get("content") or ""
+            if not token:
+                continue
+            accumulated += token
+            is_sentence_end = any(token.endswith(p) for p in SENTENCE_ENDERS)
+            yield LLMResponseChunk(
+                token=token,
+                accumulated_text=accumulated,
+                is_sentence_end=is_sentence_end,
+                is_final=False,
+            )
+
+        yield LLMResponseChunk(
+            token="",
+            accumulated_text=accumulated,
+            is_sentence_end=True,
+            is_final=True,
+        )
+
+    async def shutdown(self) -> None:
+        pass

--- a/infra/cyberverse_config.example.yaml
+++ b/infra/cyberverse_config.example.yaml
@@ -104,6 +104,11 @@ inference:
             api_key: "${OPENAI_API_KEY}"
             model: "gpt-4o"
             temperature: 0.7 # Sampling randomness for LLM output.
+        litellm:
+            plugin_class: "inference.plugins.llm.litellm_plugin.LiteLLMPlugin"
+            model: "anthropic/claude-sonnet-4-6" # Any litellm model string.
+            temperature: 0.7
+            # api_key: "${ANTHROPIC_API_KEY}" # Or set provider env vars directly.
 
     embedding:
         # Used by local character RAG indexes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ inference = [
     "grpcio-health-checking>=1.60",
 ]
 llm = ["openai>=1.0"]
+litellm = ["litellm>=1.80,<1.87"]
 tts = ["openai>=1.0", "scipy>=1.10"]
 omni = ["websockets>=12.0"]
 voice_llm = ["websockets>=12.0"]

--- a/tests/unit/test_litellm_plugin.py
+++ b/tests/unit/test_litellm_plugin.py
@@ -1,0 +1,170 @@
+"""Tests for LiteLLM LLM plugin with mocked litellm client."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from inference.core.types import PluginConfig
+from inference.plugins.llm.litellm_plugin import LiteLLMPlugin
+from inference.plugins.llm.openai_plugin import SENTENCE_ENDERS
+
+
+class TestLiteLLMPlugin:
+    def test_name(self):
+        assert LiteLLMPlugin.name == "llm.litellm"
+
+    def test_supports_images(self):
+        assert LiteLLMPlugin.supports_images is True
+
+    def test_sentence_enders(self):
+        assert "." in SENTENCE_ENDERS
+        assert "。" in SENTENCE_ENDERS
+        assert "!" in SENTENCE_ENDERS
+
+    @pytest.mark.asyncio
+    async def test_initialize(self):
+        plugin = LiteLLMPlugin()
+        config = PluginConfig(
+            plugin_name="llm.litellm",
+            params={
+                "model": "anthropic/claude-sonnet-4-6",
+                "temperature": 0.3,
+                "api_key": "sk-test",
+                "system_prompt": "Be concise.",
+            },
+        )
+        await plugin.initialize(config)
+        assert plugin.model == "anthropic/claude-sonnet-4-6"
+        assert plugin.temperature == 0.3
+        assert plugin.api_key == "sk-test"
+        assert plugin.system_prompt == "Be concise."
+
+    @pytest.mark.asyncio
+    async def test_initialize_defaults(self):
+        plugin = LiteLLMPlugin()
+        config = PluginConfig(plugin_name="llm.litellm", params={})
+        await plugin.initialize(config)
+        assert plugin.model == "gpt-4o"
+        assert plugin.temperature == 0.7
+        assert plugin.api_key is None
+        assert plugin.system_prompt == ""
+
+    @pytest.mark.asyncio
+    async def test_generate_stream_with_mock(self):
+        plugin = LiteLLMPlugin()
+        plugin.model = "anthropic/claude-sonnet-4-6"
+        plugin.temperature = 0.7
+        plugin.system_prompt = "You are helpful."
+
+        mock_chunk1 = {"choices": [{"delta": {"content": "Hello"}}]}
+        mock_chunk2 = {"choices": [{"delta": {"content": " world."}}]}
+
+        async def mock_stream():
+            yield mock_chunk1
+            yield mock_chunk2
+
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acomp:
+            mock_acomp.return_value = mock_stream()
+
+            messages = [{"role": "user", "content": "Hi"}]
+            results = []
+            async for chunk in plugin.generate_stream(messages):
+                results.append(chunk)
+
+        assert len(results) == 3  # 2 tokens + 1 final
+        assert results[0].token == "Hello"
+        assert results[0].is_sentence_end is False
+        assert results[1].token == " world."
+        assert results[1].is_sentence_end is True
+        assert results[2].is_final is True
+        assert results[2].accumulated_text == "Hello world."
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_prepended(self):
+        plugin = LiteLLMPlugin()
+        plugin.model = "gpt-4o"
+        plugin.system_prompt = "Be concise."
+
+        async def empty_stream():
+            return
+            yield  # make it an async generator
+
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acomp:
+            mock_acomp.return_value = empty_stream()
+
+            messages = [{"role": "user", "content": "Hi"}]
+            async for _ in plugin.generate_stream(messages):
+                pass
+
+            call_kwargs = mock_acomp.call_args.kwargs
+            sent_messages = call_kwargs["messages"]
+            assert sent_messages[0]["role"] == "system"
+            assert sent_messages[0]["content"] == "Be concise."
+
+    @pytest.mark.asyncio
+    async def test_drop_params_true(self):
+        plugin = LiteLLMPlugin()
+        plugin.model = "gpt-4o"
+
+        async def empty_stream():
+            return
+            yield
+
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acomp:
+            mock_acomp.return_value = empty_stream()
+
+            messages = [{"role": "user", "content": "Hi"}]
+            async for _ in plugin.generate_stream(messages):
+                pass
+
+            call_kwargs = mock_acomp.call_args.kwargs
+            assert call_kwargs["drop_params"] is True
+            assert call_kwargs["stream"] is True
+
+    @pytest.mark.asyncio
+    async def test_api_key_forwarded(self):
+        plugin = LiteLLMPlugin()
+        plugin.model = "gpt-4o"
+        plugin.api_key = "sk-test-key"
+        plugin.api_base = "http://localhost:4000"
+
+        async def empty_stream():
+            return
+            yield
+
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acomp:
+            mock_acomp.return_value = empty_stream()
+
+            messages = [{"role": "user", "content": "Hi"}]
+            async for _ in plugin.generate_stream(messages):
+                pass
+
+            call_kwargs = mock_acomp.call_args.kwargs
+            assert call_kwargs["api_key"] == "sk-test-key"
+            assert call_kwargs["api_base"] == "http://localhost:4000"
+
+    @pytest.mark.asyncio
+    async def test_api_key_omitted_when_none(self):
+        plugin = LiteLLMPlugin()
+        plugin.model = "gpt-4o"
+        plugin.api_key = None
+        plugin.api_base = None
+
+        async def empty_stream():
+            return
+            yield
+
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acomp:
+            mock_acomp.return_value = empty_stream()
+
+            messages = [{"role": "user", "content": "Hi"}]
+            async for _ in plugin.generate_stream(messages):
+                pass
+
+            call_kwargs = mock_acomp.call_args.kwargs
+            assert "api_key" not in call_kwargs
+            assert "api_base" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_shutdown(self):
+        plugin = LiteLLMPlugin()
+        await plugin.shutdown()  # should not raise


### PR DESCRIPTION
## Summary

Adds a [LiteLLM](https://github.com/BerriAI/litellm) LLM plugin (`llm.litellm`), giving CyberVerse access to 100+ LLM providers (AWS Bedrock, Azure OpenAI, Google Vertex AI, Mistral, Cohere, etc.) through a single unified interface. Follows the existing `LLMPlugin` ABC pattern.

## Motivation

CyberVerse's plugin-based LLM architecture currently ships OpenAI and Qwen plugins. Adding each new provider requires a separate plugin implementation. LiteLLM provides a unified async streaming `acompletion()` interface that handles provider-specific auth, message formatting, and response normalization, letting users configure any provider in `cyberverse_config.yaml` without writing new code.

## Changes

- `inference/plugins/llm/litellm_plugin.py` - New `LiteLLMPlugin` implementing `LLMPlugin` ABC with async streaming via `litellm.acompletion(stream=True)`, system prompt prepending, sentence-end detection (reuses `SENTENCE_ENDERS` from openai_plugin), and `drop_params=True` for cross-provider compat.
- `pyproject.toml` - Added `litellm = ["litellm>=1.80,<1.87"]` optional dependency group
- `infra/cyberverse_config.example.yaml` - Added `litellm:` block under `inference.llm` with plugin class path and example config
- `tests/unit/test_litellm_plugin.py` - 11 unit tests covering init, defaults, streaming, system prompt, drop_params, api_key forwarding/omission, shutdown
- `README.md` - Mentioned LiteLLM in plugin stack description

## Tests

**1. Unit tests (11/11 passing):**
```
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_name PASSED
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_supports_images PASSED
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_sentence_enders PASSED
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_initialize PASSED
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_initialize_defaults PASSED
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_generate_stream_with_mock PASSED
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_system_prompt_prepended PASSED
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_drop_params_true PASSED
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_api_key_forwarded PASSED
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_api_key_omitted_when_none PASSED
tests/unit/test_litellm_plugin.py::TestLiteLLMPlugin::test_shutdown PASSED

11 passed in 0.05s
```

**2. Existing plugin tests still pass (35/35):**
```
tests/unit/test_openai_plugins.py: 14 passed
tests/unit/test_plugin_discovery.py: 10 passed
tests/unit/test_litellm_plugin.py: 11 passed
```

**3. Live E2E streaming against Anthropic via LiteLLM SDK:**
```python
plugin = LiteLLMPlugin()
await plugin.initialize(PluginConfig(
    plugin_name='llm.litellm',
    params={'model': 'anthropic/claude-sonnet-4-6', 'temperature': 0.0},
))
messages = [{'role': 'user', 'content': 'What is 2+2? Answer in one word.'}]
async for chunk in plugin.generate_stream(messages):
    if chunk.token:
        print(f'token: {chunk.token!r}  sentence_end={chunk.is_sentence_end}')
    if chunk.is_final:
        print(f'Final: {chunk.accumulated_text}')

# Output:
# token: 'Four'  sentence_end=False
# Final: Four
```

## Example config

```yaml
# cyberverse_config.yaml
inference:
    llm:
        default: "litellm"
        litellm:
            plugin_class: "inference.plugins.llm.litellm_plugin.LiteLLMPlugin"
            model: "anthropic/claude-sonnet-4-6"  # Any litellm model string
            temperature: 0.7
            # api_key: "${ANTHROPIC_API_KEY}"  # Or set provider env vars directly
```

Install: `pip install -e ".[litellm]"`

Full provider list: https://docs.litellm.ai/docs/providers

## Risk / Compatibility

- Additive only. Existing plugins (OpenAI, Qwen) are completely untouched.
- `litellm` is a separate optional dependency group - base install unaffected.
- Plugin is config-driven and dynamically imported - no changes to core server code.
- `drop_params=True` ensures cross-provider compatibility.
