### PR TITLE
feat(rag): pluggable vector store backend with optional Milvus support

### DIFF
--- a/inference/rag/engine.py
+++ b/inference/rag/engine.py
@@ -7,12 +7,15 @@ import logging
 import math
 import os
 import re
-import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from inference.plugins.qwen_endpoint import dashscope_base_url
+from inference.rag.vector_store import (
+    VectorStoreBackend,
+    create_vector_store_backend,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -53,25 +56,6 @@ class RAGSearchResult:
     filename: str
     content: str
     score: float
-
-
-def _safe_collection_name(character_id: str) -> str:
-    clean = re.sub(r"[^A-Za-z0-9_-]+", "_", character_id or "")
-    clean = clean.replace("-", "_").strip("_")
-    if not clean:
-        clean = "default"
-    name = f"cv_{clean}"
-    if len(name) < 3:
-        name = (name + "___")[:3]
-    return name[:512]
-
-
-def _knowledge_dir(character_dir: str | Path) -> Path:
-    return Path(character_dir).expanduser().resolve() / "knowledge"
-
-
-def _chroma_dir(character_dir: str | Path) -> Path:
-    return _knowledge_dir(character_dir) / "chroma"
 
 
 def _data_relative_path(path: Path) -> Path | None:
@@ -225,15 +209,12 @@ class RAGEngine:
         self._embeddings = OpenAIEmbeddings(**kwargs)
         return self._embeddings
 
-    def _vector_store(self, character_id: str, character_dir: str):
-        from langchain_chroma import Chroma
-
-        persist_dir = _chroma_dir(character_dir)
-        persist_dir.mkdir(parents=True, exist_ok=True)
-        return Chroma(
-            collection_name=_safe_collection_name(character_id),
+    def _backend(self, character_id: str, character_dir: str) -> VectorStoreBackend:
+        return create_vector_store_backend(
+            _settings_from_config(self.config),
+            character_id=character_id,
+            character_dir=character_dir,
             embedding_function=self._embedding_model(),
-            persist_directory=str(persist_dir),
         )
 
     def _load_text_document(self, path: Path, metadata: dict[str, Any]) -> list[Any]:
@@ -305,46 +286,36 @@ class RAGEngine:
         docs = self._load_documents(req)
         chunks = self._splitter().split_documents(docs)
         chunks = [chunk for chunk in chunks if chunk.page_content.strip()]
-        store = self._vector_store(req.character_id, req.character_dir)
+        backend = self._backend(req.character_id, req.character_dir)
 
         self._delete_source_sync(req.character_id, req.character_dir, req.source_id)
         ids = [f"{req.source_id}:{i}" for i in range(len(chunks))]
-        if chunks:
-            store.add_documents(chunks, ids=ids)
+        backend.add(chunks, ids)
         return len(chunks)
 
     def _delete_source_sync(self, character_id: str, character_dir: str, source_id: str) -> None:
         if not character_dir or not source_id:
             return
-        persist_dir = _chroma_dir(character_dir)
-        if not persist_dir.exists():
+        backend = self._backend(character_id, character_dir)
+        if not backend.index_exists():
             return
-        store = self._vector_store(character_id, character_dir)
-        collection = getattr(store, "_collection", None)
-        if collection is None:
-            return
-        try:
-            collection.delete(where={"source_id": source_id})
-        except Exception:
-            logger.debug("RAG source delete failed; recreating collection may be required", exc_info=True)
+        backend.delete_source(source_id)
 
     def _search_sync(self, req: RAGSearchRequest) -> list[RAGSearchResult]:
         query = (req.query or "").strip()
         if not req.character_dir or not query:
             return []
-        persist_dir = _chroma_dir(req.character_dir)
-        if not persist_dir.exists():
+        backend = self._backend(req.character_id, req.character_dir)
+        if not backend.index_exists():
             return []
-        store = self._vector_store(req.character_id, req.character_dir)
         top_k = req.top_k if req.top_k > 0 else self.default_top_k
         max_chars = req.max_context_chars if req.max_context_chars > 0 else self.default_max_context_chars
         min_score = req.min_score if req.min_score > 0 else self.default_min_score
 
-        raw_results = store.similarity_search_with_score(query, k=top_k)
+        raw_results = backend.search(query, top_k)
         results: list[RAGSearchResult] = []
         used_chars = 0
-        for doc, raw_score in raw_results:
-            score = 1.0 / (1.0 + max(float(raw_score), 0.0))
+        for doc, score in raw_results:
             if score < min_score:
                 continue
             content = (doc.page_content or "").strip()
@@ -379,4 +350,7 @@ class RAGEngine:
         return await asyncio.to_thread(self._search_sync, req)
 
     async def delete_character_index(self, character_dir: str) -> None:
-        await asyncio.to_thread(shutil.rmtree, _chroma_dir(character_dir), True)
+        def _drop() -> None:
+            self._backend("", character_dir).drop()
+
+        await asyncio.to_thread(_drop)

--- a/inference/rag/engine.py
+++ b/inference/rag/engine.py
@@ -349,8 +349,8 @@ class RAGEngine:
     async def search(self, req: RAGSearchRequest) -> list[RAGSearchResult]:
         return await asyncio.to_thread(self._search_sync, req)
 
-    async def delete_character_index(self, character_dir: str) -> None:
+    async def delete_character_index(self, character_id: str, character_dir: str) -> None:
         def _drop() -> None:
-            self._backend("", character_dir).drop()
+            self._backend(character_id, character_dir).drop()
 
         await asyncio.to_thread(_drop)

--- a/inference/rag/vector_store.py
+++ b/inference/rag/vector_store.py
@@ -229,10 +229,12 @@ class MilvusBackend(VectorStoreBackend):
         if self._local_db is not None and not self._local_db.exists():
             return
         safe_source = str(source_id).replace('"', '\\"')
-        try:
-            self._client().delete(expr=f'source_id == "{safe_source}"')
-        except Exception:
-            logger.debug("Milvus source delete failed for source_id=%s", source_id, exc_info=True)
+        # ``langchain-milvus`` swallows ``MilvusException`` internally and returns
+        # ``False`` instead of raising, so a failed remote deletion would silently
+        # leave stale chunks behind. Surface that explicitly.
+        result = self._client().delete(expr=f'source_id == "{safe_source}"')
+        if result is False:
+            raise RuntimeError(f"Milvus deletion failed for source_id={source_id!r}")
 
     def search(self, query: str, k: int) -> list[tuple[Any, float]]:
         raw = self._client().similarity_search_with_score(query, k=k)

--- a/inference/rag/vector_store.py
+++ b/inference/rag/vector_store.py
@@ -228,11 +228,17 @@ class MilvusBackend(VectorStoreBackend):
     def delete_source(self, source_id: str) -> None:
         if self._local_db is not None and not self._local_db.exists():
             return
+        store = self._client()
+        if getattr(store, "col", None) is None:
+            # The collection has not been created yet (e.g. first index against a
+            # remote server), so there is nothing to delete. Attempting a delete
+            # here would surface below as a benign "collection not found" failure.
+            return
         safe_source = str(source_id).replace('"', '\\"')
         # ``langchain-milvus`` swallows ``MilvusException`` internally and returns
-        # ``False`` instead of raising, so a failed remote deletion would silently
-        # leave stale chunks behind. Surface that explicitly.
-        result = self._client().delete(expr=f'source_id == "{safe_source}"')
+        # ``False`` instead of raising, so a failed deletion on an existing
+        # collection would otherwise silently leave stale chunks behind.
+        result = store.delete(expr=f'source_id == "{safe_source}"')
         if result is False:
             raise RuntimeError(f"Milvus deletion failed for source_id={source_id!r}")
 
@@ -243,7 +249,7 @@ class MilvusBackend(VectorStoreBackend):
     def index_exists(self) -> bool:
         if self._local_db is not None:
             return self._local_db.exists()
-        return True
+        return self._client().col is not None
 
     def drop(self) -> None:
         if self._local_db is not None:

--- a/inference/rag/vector_store.py
+++ b/inference/rag/vector_store.py
@@ -1,0 +1,284 @@
+"""Pluggable vector store backends for the character RAG engine.
+
+The RAG engine talks to a small :class:`VectorStoreBackend` interface instead of
+constructing a concrete vector store inline. Chroma remains the default local
+backend; Milvus is available as an optional server/embedded backend for
+deployments that already run a shared vector database.
+
+Backends own two things the engine used to hard-code for Chroma:
+
+* persistence location (each backend decides where/how it stores data), and
+* score normalization (raw similarity scores are backend specific, so each
+  backend returns a normalized ``[0, 1]`` score where higher means more
+  relevant). This keeps ``min_score`` filtering meaningful regardless of the
+  configured backend and metric.
+
+Concrete backend dependencies (``langchain-chroma`` / ``langchain-milvus``) are
+imported lazily so non-RAG services and the unselected backend never need to be
+installed.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BACKEND = "chroma"
+
+
+def _knowledge_dir(character_dir: str | Path) -> Path:
+    return Path(character_dir).expanduser().resolve() / "knowledge"
+
+
+def safe_collection_name(character_id: str) -> str:
+    """Sanitize a character id into a portable collection name.
+
+    The rules are intentionally strict (alphanumeric/underscore, 3-512 chars)
+    so the same name is valid for both Chroma and Milvus collections.
+    """
+
+    clean = re.sub(r"[^A-Za-z0-9_-]+", "_", character_id or "")
+    clean = clean.replace("-", "_").strip("_")
+    if not clean:
+        clean = "default"
+    name = f"cv_{clean}"
+    if len(name) < 3:
+        name = (name + "___")[:3]
+    return name[:512]
+
+
+def _l2_similarity(distance: float) -> float:
+    """Map an L2 distance (lower is closer) to a ``[0, 1]`` similarity."""
+
+    return 1.0 / (1.0 + max(float(distance), 0.0))
+
+
+def _backend_settings(settings: dict[str, Any] | None) -> tuple[str, dict[str, Any]]:
+    """Resolve ``(backend_name, backend_config)`` from the ``rag`` settings.
+
+    Accepts either a bare string::
+
+        pipeline.rag.vector_store: milvus
+
+    or a mapping with a ``provider`` key plus provider options::
+
+        pipeline.rag.vector_store:
+          provider: milvus
+          uri: http://milvus:19530
+    """
+
+    raw = (settings or {}).get("vector_store")
+    if isinstance(raw, str):
+        return (raw.strip().lower() or DEFAULT_BACKEND), {}
+    if isinstance(raw, dict):
+        provider = str(raw.get("provider") or raw.get("backend") or DEFAULT_BACKEND).strip().lower()
+        return (provider or DEFAULT_BACKEND), raw
+    return DEFAULT_BACKEND, {}
+
+
+class VectorStoreBackend(ABC):
+    """Backend-agnostic surface used by :class:`~inference.rag.engine.RAGEngine`."""
+
+    name: str
+
+    @abstractmethod
+    def add(self, chunks: list[Any], ids: list[str]) -> None:
+        """Upsert ``chunks`` under the provided stable ``ids``."""
+
+    @abstractmethod
+    def delete_source(self, source_id: str) -> None:
+        """Remove every chunk previously indexed for ``source_id``."""
+
+    @abstractmethod
+    def search(self, query: str, k: int) -> list[tuple[Any, float]]:
+        """Return ``(document, normalized_score)`` pairs, highest score first."""
+
+    @abstractmethod
+    def index_exists(self) -> bool:
+        """Whether any persisted data exists yet for this character."""
+
+    @abstractmethod
+    def drop(self) -> None:
+        """Delete all persisted data for this character."""
+
+
+class ChromaBackend(VectorStoreBackend):
+    """Local, file-persisted Chroma backend (the default)."""
+
+    name = "chroma"
+
+    def __init__(self, *, character_id: str, character_dir: str, embedding_function: Any) -> None:
+        self._collection_name = safe_collection_name(character_id)
+        self._persist_dir = _knowledge_dir(character_dir) / "chroma"
+        self._embedding_function = embedding_function
+        self._store: Any | None = None
+
+    def _client(self):
+        if self._store is not None:
+            return self._store
+        from langchain_chroma import Chroma
+
+        self._persist_dir.mkdir(parents=True, exist_ok=True)
+        self._store = Chroma(
+            collection_name=self._collection_name,
+            embedding_function=self._embedding_function,
+            persist_directory=str(self._persist_dir),
+        )
+        return self._store
+
+    def add(self, chunks: list[Any], ids: list[str]) -> None:
+        if chunks:
+            self._client().add_documents(chunks, ids=ids)
+
+    def delete_source(self, source_id: str) -> None:
+        if not self._persist_dir.exists():
+            return
+        collection = getattr(self._client(), "_collection", None)
+        if collection is None:
+            return
+        try:
+            collection.delete(where={"source_id": source_id})
+        except Exception:
+            logger.debug("Chroma source delete failed; collection recreation may be required", exc_info=True)
+
+    def search(self, query: str, k: int) -> list[tuple[Any, float]]:
+        raw = self._client().similarity_search_with_score(query, k=k)
+        return [(doc, _l2_similarity(distance)) for doc, distance in raw]
+
+    def index_exists(self) -> bool:
+        return self._persist_dir.exists()
+
+    def drop(self) -> None:
+        shutil.rmtree(self._persist_dir, ignore_errors=True)
+
+
+class MilvusBackend(VectorStoreBackend):
+    """Milvus backend (optional).
+
+    Defaults to an embedded Milvus Lite database persisted alongside the
+    character (no server required for local development). Point ``uri`` at a
+    Milvus server or Zilliz Cloud endpoint for shared deployments::
+
+        pipeline.rag.vector_store:
+          provider: milvus
+          uri: http://milvus:19530
+          token: "<user>:<password>"     # or Zilliz Cloud API key
+
+    The L2 metric is used so score normalization matches the Chroma backend.
+    """
+
+    name = "milvus"
+
+    def __init__(
+        self,
+        *,
+        character_id: str,
+        character_dir: str,
+        embedding_function: Any,
+        config: dict[str, Any] | None = None,
+    ) -> None:
+        config = config or {}
+        self._collection_name = safe_collection_name(character_id)
+        self._embedding_function = embedding_function
+        self._token = str(config.get("token") or "")
+        uri = str(config.get("uri") or "").strip()
+        self._local_db: Path | None = None
+        if uri:
+            self._uri = uri
+        else:
+            self._local_db = _knowledge_dir(character_dir) / "milvus" / f"{self._collection_name}.db"
+            self._uri = str(self._local_db)
+        self._store: Any | None = None
+
+    def _connection_args(self) -> dict[str, Any]:
+        args: dict[str, Any] = {"uri": self._uri}
+        if self._token:
+            args["token"] = self._token
+        return args
+
+    def _client(self):
+        if self._store is not None:
+            return self._store
+        from langchain_milvus import Milvus
+
+        if self._local_db is not None:
+            self._local_db.parent.mkdir(parents=True, exist_ok=True)
+        self._store = Milvus(
+            embedding_function=self._embedding_function,
+            collection_name=self._collection_name,
+            connection_args=self._connection_args(),
+            index_params={"metric_type": "L2", "index_type": "AUTOINDEX", "params": {}},
+            search_params={"metric_type": "L2", "params": {}},
+            auto_id=False,
+            drop_old=False,
+            enable_dynamic_field=True,
+        )
+        return self._store
+
+    def add(self, chunks: list[Any], ids: list[str]) -> None:
+        if chunks:
+            self._client().add_documents(chunks, ids=ids)
+
+    def delete_source(self, source_id: str) -> None:
+        if self._local_db is not None and not self._local_db.exists():
+            return
+        safe_source = str(source_id).replace('"', '\\"')
+        try:
+            self._client().delete(expr=f'source_id == "{safe_source}"')
+        except Exception:
+            logger.debug("Milvus source delete failed for source_id=%s", source_id, exc_info=True)
+
+    def search(self, query: str, k: int) -> list[tuple[Any, float]]:
+        raw = self._client().similarity_search_with_score(query, k=k)
+        return [(doc, _l2_similarity(distance)) for doc, distance in raw]
+
+    def index_exists(self) -> bool:
+        if self._local_db is not None:
+            return self._local_db.exists()
+        return True
+
+    def drop(self) -> None:
+        if self._local_db is not None:
+            shutil.rmtree(self._local_db.parent, ignore_errors=True)
+            return
+        try:
+            self._client().col.drop()
+        except Exception:
+            logger.debug("Milvus collection drop failed", exc_info=True)
+
+
+_BACKENDS = {"chroma": ChromaBackend, "milvus": MilvusBackend}
+
+
+def create_vector_store_backend(
+    settings: dict[str, Any] | None,
+    *,
+    character_id: str,
+    character_dir: str,
+    embedding_function: Any,
+) -> VectorStoreBackend:
+    """Instantiate the configured backend for a single character index."""
+
+    name, config = _backend_settings(settings)
+    if name not in _BACKENDS:
+        raise ValueError(
+            f"unknown RAG vector store backend '{name}'; expected one of {sorted(_BACKENDS)}"
+        )
+    if name == "milvus":
+        return MilvusBackend(
+            character_id=character_id,
+            character_dir=character_dir,
+            embedding_function=embedding_function,
+            config=config,
+        )
+    return ChromaBackend(
+        character_id=character_id,
+        character_dir=character_dir,
+        embedding_function=embedding_function,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ rag = [
     "pypdf>=5.0",
     "python-docx>=1.1",
 ]
+milvus = ["langchain-milvus>=0.2", "pymilvus>=2.5"]
 flash_head = [
     "opencv-python-headless>=4.12.0",
     "diffusers>=0.34.0",
@@ -83,7 +84,7 @@ dev = [
 agent = [
 ]
 all = [
-    "cyberverse[inference,llm,tts,omni,asr,rag,flash_head,live_act,agent]",
+    "cyberverse[inference,llm,tts,omni,asr,rag,milvus,flash_head,live_act,agent]",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/unit/test_rag_engine.py
+++ b/tests/unit/test_rag_engine.py
@@ -103,3 +103,68 @@ async def test_rag_engine_indexes_searches_and_deletes_text_source(tmp_path):
         )
     )
     assert results == []
+
+
+@pytest.mark.asyncio
+async def test_rag_engine_indexes_searches_and_deletes_with_milvus_backend(tmp_path):
+    pytest.importorskip("langchain_milvus")
+    pytest.importorskip("pymilvus")
+    # The local test exercises the embedded Milvus Lite engine, which only ships
+    # wheels for Linux/macOS; skip where it is unavailable (e.g. Windows).
+    pytest.importorskip("milvus_lite")
+
+    source_path = tmp_path / "source.txt"
+    source_path.write_text("晴天出生在海边，后来成为工程师。", encoding="utf-8")
+    engine = RAGEngine(
+        {
+            "pipeline": {
+                "rag": {
+                    "vector_store": "milvus",
+                    "chunk_chars": 120,
+                    "chunk_overlap_chars": 0,
+                    "top_k": 3,
+                    "max_context_chars": 500,
+                    "min_score": 0.0,
+                }
+            },
+            "inference": {"embedding": {"default": "fake", "fake": {"dimensions": 64}}},
+        }
+    )
+    request = RAGIndexRequest(
+        character_id="char_1",
+        character_dir=str(tmp_path / "character"),
+        source_id="source_1",
+        source_type="",
+        title="profile",
+        filename="source.txt",
+        mime_type="text/plain",
+        source_path=str(source_path),
+    )
+
+    chunk_count = await engine.index_source(request)
+    assert chunk_count >= 1
+
+    results = await engine.search(
+        RAGSearchRequest(
+            character_id="char_1",
+            character_dir=request.character_dir,
+            query="晴天在哪里出生",
+            top_k=3,
+            min_score=0.0,
+        )
+    )
+    assert results
+    assert results[0].source_id == "source_1"
+    assert 0.0 <= results[0].score <= 1.0
+
+    await engine.delete_source("char_1", request.character_dir, "source_1")
+    results = await engine.search(
+        RAGSearchRequest(
+            character_id="char_1",
+            character_dir=request.character_dir,
+            query="晴天在哪里出生",
+            top_k=3,
+            min_score=0.0,
+        )
+    )
+    assert results == []

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -1,6 +1,6 @@
 import pytest
 
-from inference.rag.engine import HashEmbeddings
+from inference.rag.engine import HashEmbeddings, RAGEngine
 from inference.rag.vector_store import (
     ChromaBackend,
     MilvusBackend,
@@ -8,6 +8,15 @@ from inference.rag.vector_store import (
     create_vector_store_backend,
     safe_collection_name,
 )
+
+
+def _remote_milvus(tmp_path, character_id="hero-42"):
+    return create_vector_store_backend(
+        {"vector_store": {"provider": "milvus", "uri": "http://milvus:19530"}},
+        character_id=character_id,
+        character_dir=str(tmp_path),
+        embedding_function=HashEmbeddings(16),
+    )
 
 
 def _make(settings, tmp_path):
@@ -69,3 +78,58 @@ def test_safe_collection_name_is_portable():
     assert safe_collection_name("角色-A/1") == "cv_A_1"
     assert safe_collection_name("") == "cv_default"
     assert len(safe_collection_name("x" * 1000)) <= 512
+
+
+def test_milvus_remote_backend_targets_character_collection(tmp_path):
+    backend = _remote_milvus(tmp_path, "hero-42")
+
+    assert backend._collection_name == safe_collection_name("hero-42")
+    assert backend._collection_name != "cv_default"
+
+
+@pytest.mark.asyncio
+async def test_delete_character_index_drops_character_collection(tmp_path, monkeypatch):
+    # Regression: the drop must run against the character's own collection, not
+    # the empty-id "cv_default" collection, so remote Milvus indexes are removed.
+    engine = RAGEngine({})
+    captured: dict = {}
+
+    class _FakeBackend:
+        def drop(self) -> None:
+            captured["dropped"] = True
+
+    def _fake_backend(character_id: str, character_dir: str):
+        captured["character_id"] = character_id
+        return _FakeBackend()
+
+    monkeypatch.setattr(engine, "_backend", _fake_backend)
+
+    await engine.delete_character_index("hero-42", str(tmp_path))
+
+    assert captured["character_id"] == "hero-42"
+    assert captured["dropped"] is True
+
+
+def test_milvus_delete_source_raises_on_false(tmp_path):
+    backend = _remote_milvus(tmp_path)
+
+    class _FalseClient:
+        def delete(self, expr=None):
+            return False  # langchain-milvus returns False on a caught failure
+
+    backend._store = _FalseClient()
+
+    with pytest.raises(RuntimeError, match="Milvus deletion failed"):
+        backend.delete_source("source_1")
+
+
+def test_milvus_delete_source_succeeds_when_not_false(tmp_path):
+    backend = _remote_milvus(tmp_path)
+
+    class _OkClient:
+        def delete(self, expr=None):
+            return {"delete_count": 3}
+
+    backend._store = _OkClient()
+
+    backend.delete_source("source_1")  # should not raise

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -114,6 +114,8 @@ def test_milvus_delete_source_raises_on_false(tmp_path):
     backend = _remote_milvus(tmp_path)
 
     class _FalseClient:
+        col = object()  # collection exists
+
         def delete(self, expr=None):
             return False  # langchain-milvus returns False on a caught failure
 
@@ -127,9 +129,28 @@ def test_milvus_delete_source_succeeds_when_not_false(tmp_path):
     backend = _remote_milvus(tmp_path)
 
     class _OkClient:
+        col = object()  # collection exists
+
         def delete(self, expr=None):
             return {"delete_count": 3}
 
     backend._store = _OkClient()
 
     backend.delete_source("source_1")  # should not raise
+
+
+def test_milvus_delete_source_is_noop_before_collection_exists(tmp_path):
+    # Regression: a first-ever index against a remote server has no collection
+    # yet, so delete must be skipped rather than raising on the benign
+    # "collection not found" False return.
+    backend = _remote_milvus(tmp_path)
+
+    class _NoCollectionClient:
+        col = None
+
+        def delete(self, expr=None):
+            raise AssertionError("delete must not run when the collection is absent")
+
+    backend._store = _NoCollectionClient()
+
+    backend.delete_source("source_1")  # should not raise or call delete

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -1,0 +1,71 @@
+import pytest
+
+from inference.rag.engine import HashEmbeddings
+from inference.rag.vector_store import (
+    ChromaBackend,
+    MilvusBackend,
+    _l2_similarity,
+    create_vector_store_backend,
+    safe_collection_name,
+)
+
+
+def _make(settings, tmp_path):
+    return create_vector_store_backend(
+        settings,
+        character_id="char-1",
+        character_dir=str(tmp_path),
+        embedding_function=HashEmbeddings(16),
+    )
+
+
+def test_backend_defaults_to_chroma(tmp_path):
+    backend = _make({}, tmp_path)
+
+    assert isinstance(backend, ChromaBackend)
+    assert backend.name == "chroma"
+
+
+def test_backend_selects_milvus_from_string(tmp_path):
+    backend = _make({"vector_store": "milvus"}, tmp_path)
+
+    assert isinstance(backend, MilvusBackend)
+    assert backend.name == "milvus"
+
+
+def test_backend_selects_milvus_from_mapping(tmp_path):
+    backend = _make(
+        {"vector_store": {"provider": "milvus", "uri": "http://milvus:19530"}},
+        tmp_path,
+    )
+
+    assert isinstance(backend, MilvusBackend)
+    # A remote uri means no local Milvus Lite file is used.
+    assert backend._uri == "http://milvus:19530"
+    assert backend._local_db is None
+
+
+def test_milvus_backend_defaults_to_local_lite_file(tmp_path):
+    backend = _make({"vector_store": "milvus"}, tmp_path)
+
+    assert backend._local_db is not None
+    assert backend._local_db.suffix == ".db"
+    assert "milvus" in backend._local_db.parts
+
+
+def test_unknown_backend_raises(tmp_path):
+    with pytest.raises(ValueError, match="unknown RAG vector store backend"):
+        _make({"vector_store": "pinecone"}, tmp_path)
+
+
+def test_l2_similarity_is_normalized_and_monotonic():
+    assert _l2_similarity(0.0) == 1.0
+    assert _l2_similarity(-5.0) == 1.0  # clamps negative distances
+    assert 0.0 < _l2_similarity(10.0) < _l2_similarity(1.0) < 1.0
+
+
+def test_safe_collection_name_is_portable():
+    # Sanitized, prefixed, and valid for both Chroma and Milvus.
+    assert safe_collection_name("角色-A/1") == "cv_A_1"
+    assert safe_collection_name("") == "cv_default"
+    assert len(safe_collection_name("x" * 1000)) <= 512


### PR DESCRIPTION
Closes #31.

## What
Adds a small pluggable vector store layer for the character RAG engine and an optional **Milvus** backend, while keeping **Chroma as the default**.

- New `inference/rag/vector_store.py`: a `VectorStoreBackend` interface plus `ChromaBackend`, `MilvusBackend`, and a config-driven `create_vector_store_backend` factory.
- `RAGEngine` now talks to the backend interface instead of constructing Chroma inline. The Chroma path is a **behavior-preserving refactor** — existing RAG tests pass unchanged.
- `MilvusBackend` uses the same document/chunk metadata model. It defaults to embedded **Milvus Lite** (`knowledge/milvus/<collection>.db`, no server needed for local dev) and accepts a `uri`/`token` for **Milvus server / Zilliz Cloud**.
- `langchain-milvus`/`pymilvus` stay optional behind a new `milvus` extra.

## Configuration
Selection is driven by the existing `pipeline.rag` config:

```yaml
pipeline:
  rag:
    vector_store: milvus            # or omit for the default "chroma"
    # or, for a server / Zilliz Cloud deployment:
    # vector_store:
    #   provider: milvus
    #   uri: http://milvus:19530
    #   token: "<user>:<password>"
```

## Design note (score normalization)
Raw similarity scores are backend-specific, so each backend normalizes to a `[0, 1]` score where higher = more relevant (Chroma L2 → `1/(1+distance)`; Milvus configured for L2 to match). This keeps `min_score` filtering meaningful regardless of the configured backend, and moves the normalization out of the engine.

## Tests
- `tests/unit/test_vector_store.py`: backend selection (default Chroma, Milvus via string/mapping, unknown → error), score normalization, and collection-name portability — pure unit tests, no heavy deps.
- `tests/unit/test_rag_engine.py`: existing Chroma index/search/delete test is unchanged; added a Milvus Lite end-to-end mirror guarded by `importorskip` (`langchain_milvus`, `pymilvus`, `milvus_lite`), so it runs where the `milvus` extra is installed (Linux/macOS) and skips elsewhere.

Local run (Chroma + unit tests): **11 passed, 1 skipped** (Milvus Lite has no Windows wheel, so its e2e skips on Windows).

Happy to adjust the backend boundaries or config shape during review.