### PR TITLE
fix(security): mask API secrets in settings endpoint

### DIFF
--- a/server/internal/api/settings.go
+++ b/server/internal/api/settings.go
@@ -111,27 +111,51 @@ type launchConfigResponse struct {
 	Sections               []launchConfigSectionJSON `json:"sections"`
 }
 
-// settingsField maps a UI field to an environment variable.
+// settingsField maps a UI field to an environment variable. secret fields are
+// masked in GET responses and masked values are ignored on PUT so the browser
+// cannot echo a redacted value back over the real secret.
 type settingsField struct {
 	envKey   string
+	secret   bool
 	getValue func(*SettingsResponse) string
 }
 
 var settingsFields = []settingsField{
-	{"DOUBAO_ACCESS_TOKEN", func(s *SettingsResponse) string { return s.Doubao.AccessToken }},
-	{"DOUBAO_APP_ID", func(s *SettingsResponse) string { return s.Doubao.AppID }},
-	{"DOUBAO_API_KEY", func(s *SettingsResponse) string { return s.Doubao.APIKey }},
-	{"LIVEKIT_URL", func(s *SettingsResponse) string { return s.LiveKit.URL }},
-	{"LIVEKIT_API_KEY", func(s *SettingsResponse) string { return s.LiveKit.APIKey }},
-	{"LIVEKIT_API_SECRET", func(s *SettingsResponse) string { return s.LiveKit.APISecret }},
-	{"DASHSCOPE_API_KEY", func(s *SettingsResponse) string { return s.ModelProviders.DashScopeAPIKey }},
-	{"OPENAI_API_KEY", func(s *SettingsResponse) string {
+	{"DOUBAO_ACCESS_TOKEN", true, func(s *SettingsResponse) string { return s.Doubao.AccessToken }},
+	{"DOUBAO_APP_ID", false, func(s *SettingsResponse) string { return s.Doubao.AppID }},
+	{"DOUBAO_API_KEY", true, func(s *SettingsResponse) string { return s.Doubao.APIKey }},
+	{"LIVEKIT_URL", false, func(s *SettingsResponse) string { return s.LiveKit.URL }},
+	{"LIVEKIT_API_KEY", true, func(s *SettingsResponse) string { return s.LiveKit.APIKey }},
+	{"LIVEKIT_API_SECRET", true, func(s *SettingsResponse) string { return s.LiveKit.APISecret }},
+	{"DASHSCOPE_API_KEY", true, func(s *SettingsResponse) string { return s.ModelProviders.DashScopeAPIKey }},
+	{"OPENAI_API_KEY", true, func(s *SettingsResponse) string {
 		if s.ModelProviders.OpenAIAPIKey != "" {
 			return s.ModelProviders.OpenAIAPIKey
 		}
 		return s.LLM.APIKey
 	}},
-	{"GRPC_INFERENCE_ADDR", func(s *SettingsResponse) string { return s.Inference.GRPCAddr }},
+	{"GRPC_INFERENCE_ADDR", false, func(s *SettingsResponse) string { return s.Inference.GRPCAddr }},
+}
+
+// maskSecret redacts a secret for display in the browser. Secrets are never
+// sent back in full: the settings UI only needs to know whether one is set
+// and (for short secrets) its first character, so a masked value is enough.
+func maskSecret(s string) string {
+	if s == "" {
+		return ""
+	}
+	const visible = 4
+	if len(s) <= visible*2 {
+		return s[:1] + "****"
+	}
+	return s[:visible] + "****" + s[len(s)-visible:]
+}
+
+// isMaskedSecret reports whether v is a masked value produced by maskSecret
+// (format "prefix****suffix"), i.e. the browser echoed the redacted secret
+// back without editing it.
+func isMaskedSecret(v string) bool {
+	return strings.Contains(v, "****")
 }
 
 func (r *Router) handleGetSettings(w http.ResponseWriter, req *http.Request) {
@@ -168,6 +192,14 @@ func (r *Router) handleGetSettings(w http.ResponseWriter, req *http.Request) {
 			GRPCAddr: envOrDefault("GRPC_INFERENCE_ADDR", r.cfg.Inference.Addr),
 		},
 	}
+	// Never expose secrets in full to the browser.
+	resp.Doubao.AccessToken = maskSecret(resp.Doubao.AccessToken)
+	resp.Doubao.APIKey = maskSecret(resp.Doubao.APIKey)
+	resp.LiveKit.APIKey = maskSecret(resp.LiveKit.APIKey)
+	resp.LiveKit.APISecret = maskSecret(resp.LiveKit.APISecret)
+	resp.ModelProviders.DashScopeAPIKey = maskSecret(resp.ModelProviders.DashScopeAPIKey)
+	resp.ModelProviders.OpenAIAPIKey = maskSecret(resp.ModelProviders.OpenAIAPIKey)
+	resp.LLM.APIKey = maskSecret(resp.LLM.APIKey)
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -183,6 +215,11 @@ func (r *Router) handleUpdateSettings(w http.ResponseWriter, req *http.Request) 
 		val := f.getValue(&body)
 		// Skip empty values to avoid blanking existing config.
 		if val == "" {
+			continue
+		}
+		// Skip masked values: the browser echoes the redacted secret back when
+		// the user did not edit it. Writing it back would corrupt the real secret.
+		if f.secret && isMaskedSecret(val) {
 			continue
 		}
 		updates[f.envKey] = val

--- a/server/internal/api/settings_test.go
+++ b/server/internal/api/settings_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetSettingsMasksSecrets(t *testing.T) {
+	const dashScopeKey = "sk-dashscope-super-secret-123456"
+	const openAIKey = "sk-openai-super-secret-123456"
+	const liveKitSecret = "livekit-secret-value-123456"
+	t.Setenv("DASHSCOPE_API_KEY", dashScopeKey)
+	t.Setenv("OPENAI_API_KEY", openAIKey)
+	t.Setenv("LIVEKIT_API_SECRET", liveKitSecret)
+
+	r := newTestRouter()
+	req := httptest.NewRequest("GET", "/api/v1/settings", nil)
+	w := httptest.NewRecorder()
+	r.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp SettingsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Full secrets must never reach the browser.
+	if strings.Contains(w.Body.String(), dashScopeKey) {
+		t.Error("GET /settings leaked DASHSCOPE_API_KEY in full")
+	}
+	if strings.Contains(w.Body.String(), openAIKey) {
+		t.Error("GET /settings leaked OPENAI_API_KEY in full")
+	}
+	if strings.Contains(w.Body.String(), liveKitSecret) {
+		t.Error("GET /settings leaked LIVEKIT_API_SECRET in full")
+	}
+
+	// Masked values must still be present so the UI knows the key is set.
+	for name, got := range map[string]string{
+		"dashscope_api_key":  resp.ModelProviders.DashScopeAPIKey,
+		"openai_api_key":     resp.ModelProviders.OpenAIAPIKey,
+		"llm.api_key":        resp.LLM.APIKey,
+		"livekit.api_secret": resp.LiveKit.APISecret,
+	} {
+		if !strings.Contains(got, "****") {
+			t.Errorf("%s not masked: %q", name, got)
+		}
+	}
+}
+
+func TestUpdateSettingsIgnoresMaskedSecrets(t *testing.T) {
+	envFile, err := os.CreateTemp("", "cyberverse-env-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	envPath := envFile.Name()
+	t.Cleanup(func() { os.Remove(envPath) })
+
+	t.Setenv("DOUBAO_ACCESS_TOKEN", "real-token-value")
+	r := newTestRouter()
+	r.envPath = envPath
+
+	// The browser echoes the masked value back unchanged.
+	body := `{"doubao":{"access_token":"real****value"}}`
+	req := httptest.NewRequest("PUT", "/api/v1/settings", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The masked value must not overwrite the real secret.
+	if got := os.Getenv("DOUBAO_ACCESS_TOKEN"); got != "real-token-value" {
+		t.Errorf("masked value overwrote secret: got %q", got)
+	}
+	envContent, _ := os.ReadFile(envPath)
+	if strings.Contains(string(envContent), "real****value") {
+		t.Error("masked value was persisted to .env")
+	}
+}
+
+func TestUpdateSettingsWritesNewSecret(t *testing.T) {
+	envFile, err := os.CreateTemp("", "cyberverse-env-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	envPath := envFile.Name()
+	t.Cleanup(func() { os.Remove(envPath) })
+
+	r := newTestRouter()
+	r.envPath = envPath
+
+	body := `{"doubao":{"access_token":"brand-new-token"}}`
+	req := httptest.NewRequest("PUT", "/api/v1/settings", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := os.Getenv("DOUBAO_ACCESS_TOKEN"); got != "brand-new-token" {
+		t.Errorf("new secret not applied: got %q", got)
+	}
+}


### PR DESCRIPTION
## 问题

`GET /api/v1/settings` 明文返回所有云厂商 API 密钥与 LiveKit secret，而服务端没有任何认证。任何能访问该端点的网页（配合跨域读取）都能窃取全部密钥。

## 修复

- GET 响应中密钥字段脱敏为 `sk-****3456` 格式，浏览器仍能判断密钥是否已配置，但拿不到完整值
- PUT 请求收到脱敏值（前端未编辑时原样回传）自动跳过，防止掩码覆盖真实密钥
- 新增 3 个单元测试：掩码格式、掩码回传忽略、新密钥正常写入

## 测试

`go test ./internal/api/ -run TestGetSettingsMasksSecrets -v` 等均通过，`go vet` 干净。