### PR TITLE
fix(security): enforce origin allowlist for CORS and WebSocket

### DIFF
--- a/infra/config/cyberverse.yaml
+++ b/infra/config/cyberverse.yaml
@@ -9,7 +9,10 @@ server:
     host: "0.0.0.0"
     http_port: 8080
     grpc_port: 50051
-    cors_origins: ["*"]
+    # Allowed cross-origin API/WebSocket clients. Local development origins
+    # (localhost / 127.0.0.1) are always allowed. Add your production frontend
+    # origin here; an explicit "*" entry restores the legacy wildcard behavior.
+    cors_origins: ["https://www.cyberverse.cc"]
 
 livekit:
     url: "${LIVEKIT_URL}"

--- a/server/internal/api/cors_test.go
+++ b/server/internal/api/cors_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCORSAllowsAllowlistedOrigin(t *testing.T) {
+	r := newTestRouter() // CORSOrigins includes https://app.example.com
+
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	w := httptest.NewRecorder()
+	r.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://app.example.com" {
+		t.Errorf("expected allowlisted origin echoed, got %q", got)
+	}
+}
+
+func TestCORSAllowsLocalhostOrigin(t *testing.T) {
+	r := newTestRouter()
+
+	for _, origin := range []string{"http://localhost:5173", "http://127.0.0.1:8080"} {
+		req := httptest.NewRequest("GET", "/api/v1/health", nil)
+		req.Header.Set("Origin", origin)
+		w := httptest.NewRecorder()
+		r.Handler().ServeHTTP(w, req)
+
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != origin {
+			t.Errorf("origin %s: expected echoed, got %q", origin, got)
+		}
+	}
+}
+
+func TestCORSRejectsUnknownOrigin(t *testing.T) {
+	r := newTestRouter()
+
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	r.Handler().ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("unexpected ACAO header for disallowed origin: %q", got)
+	}
+}
+
+func TestCORSRejectsPreflightFromUnknownOrigin(t *testing.T) {
+	r := newTestRouter()
+
+	req := httptest.NewRequest("OPTIONS", "/api/v1/health", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	r.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for disallowed preflight, got %d", w.Code)
+	}
+}
+
+func TestCORSKeepsWildcardForNoOrigin(t *testing.T) {
+	r := newTestRouter()
+
+	req := httptest.NewRequest("GET", "/api/v1/health", nil)
+	w := httptest.NewRecorder()
+	r.Handler().ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("expected wildcard for non-browser request, got %q", got)
+	}
+}
+
+func TestOriginAllowed(t *testing.T) {
+	r := newTestRouter()
+
+	allowed := []string{
+		"http://localhost:3000",
+		"https://127.0.0.1:9443",
+		"https://app.example.com",
+	}
+	for _, origin := range allowed {
+		if !r.originAllowed(origin) {
+			t.Errorf("origin %q should be allowed", origin)
+		}
+	}
+
+	denied := []string{
+		"https://evil.example.com",
+		"https://localhost.evil.com",
+		"http://notlocalhost",
+		"file:///etc/passwd",
+	}
+	for _, origin := range denied {
+		if r.originAllowed(origin) {
+			t.Errorf("origin %q should be denied", origin)
+		}
+	}
+}

--- a/server/internal/api/handlers_test.go
+++ b/server/internal/api/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cyberverse/server/internal/character"
+	"github.com/cyberverse/server/internal/config"
 	"github.com/cyberverse/server/internal/inference"
 	"github.com/cyberverse/server/internal/orchestrator"
 	pb "github.com/cyberverse/server/internal/pb"
@@ -54,7 +55,10 @@ func newTestRouterWithMgrAndInference(mgr *orchestrator.SessionManager, inf *fak
 		inf.avatarInfo = &pb.AvatarInfo{ModelName: "avatar.flash_head", OutputFps: 25, OutputWidth: 512, OutputHeight: 512}
 	}
 	orch := orchestrator.New(inf, hub, mgr, nil, cs)
-	return NewRouter(mgr, orch, hub, nil, nil, cs, "", "")
+	cfg := &config.Config{
+		Server: config.ServerConfig{CORSOrigins: []string{"https://app.example.com"}},
+	}
+	return NewRouter(mgr, orch, hub, nil, cfg, cs, "", "")
 }
 
 func TestHealthEndpoint(t *testing.T) {

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"net/url"
 	"path/filepath"
 
 	"github.com/cyberverse/server/internal/agenttask"
@@ -55,6 +56,16 @@ func NewRouter(
 	if len(taskServices) > 0 {
 		r.taskSvc = taskServices[0]
 	}
+	// WebSocket upgrades share the CORS origin allowlist enforced by
+	// corsMiddleware so both HTTP and WS reject cross-origin clients.
+	// Non-browser clients without an Origin header are always allowed.
+	ws.SetCheckOrigin(func(req *http.Request) bool {
+		origin := req.Header.Get("Origin")
+		if origin == "" {
+			return true
+		}
+		return r.originAllowed(origin)
+	})
 	r.registerRoutes()
 	return r
 }
@@ -120,20 +131,68 @@ func (r *Router) registerRoutes() {
 }
 
 func (r *Router) Handler() http.Handler {
-	return corsMiddleware(r.mux)
+	return r.corsMiddleware(r.mux)
 }
 
-func corsMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+// corsMiddleware enforces an origin allowlist on cross-origin requests.
+// Requests without an Origin header (curl, tests, same-origin) are unaffected.
+func (r *Router) corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		origin := req.Header.Get("Origin")
+		if origin == "" {
+			// Non-browser client or same-origin request; keep the wildcard
+			// behavior so plain HTTP clients are not affected.
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		} else if r.originAllowed(origin) {
+			// Echo the exact origin instead of "*" so credentials could be
+			// used later and only allowlisted origins receive the header.
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		}
 
-		if r.Method == "OPTIONS" {
+		if req.Method == http.MethodOptions {
+			// Preflight: reject explicitly when the origin is not allowed.
+			if origin != "" && !r.originAllowed(origin) {
+				writeJSON(w, http.StatusForbidden, ErrorResponse{Error: "origin not allowed"})
+				return
+			}
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(w, req)
 	})
+}
+
+// originAllowed reports whether an Origin header value is trusted. Local
+// development origins are always allowed; anything else must be listed in
+// server.cors_origins (an explicit "*" entry keeps the legacy wildcard
+// behavior for deployments that opt into it).
+func (r *Router) originAllowed(origin string) bool {
+	if isLocalhostOrigin(origin) {
+		return true
+	}
+	for _, o := range r.cfg.Server.CORSOrigins {
+		if o == "*" || o == origin {
+			return true
+		}
+	}
+	return false
+}
+
+// isLocalhostOrigin reports whether origin is a local development origin
+// (Vite dev server, local preview, etc.) on any port.
+func isLocalhostOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Hostname() == "" {
+		return false
+	}
+	switch u.Hostname() {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return false
 }

--- a/server/internal/ws/handler.go
+++ b/server/internal/ws/handler.go
@@ -11,8 +11,23 @@ var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin: func(r *http.Request) bool {
-		return true // CORS handled at router level
+		return checkOrigin(r)
 	},
+}
+
+// checkOrigin is the origin validator used for WebSocket upgrades. It is
+// installable so the API layer can share its CORS allowlist; the default
+// allows all origins to preserve existing behavior for standalone callers.
+var checkOrigin = func(r *http.Request) bool { return true }
+
+// SetCheckOrigin installs an origin validator for WebSocket upgrades.
+// Passing nil restores the default (allow all).
+func SetCheckOrigin(fn func(*http.Request) bool) {
+	if fn == nil {
+		checkOrigin = func(r *http.Request) bool { return true }
+		return
+	}
+	checkOrigin = fn
 }
 
 // HandleWebSocket returns an HTTP handler that upgrades connections to WebSocket

--- a/server/internal/ws/origin_test.go
+++ b/server/internal/ws/origin_test.go
@@ -1,0 +1,67 @@
+package ws
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+// testUpgradeResult performs a real WebSocket handshake against the package
+// handler and reports whether it was accepted. This exercises the same
+// package-level upgrader used by HandleWebSocket, whose CheckOrigin delegates
+// to checkOrigin.
+func testUpgradeResult(t *testing.T, origin string) bool {
+	t.Helper()
+
+	hub := NewHub()
+	srv := httptest.NewServer(HandleWebSocket(hub, "sess-1", nil, nil))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/chat/sess-1"
+	headers := http.Header{}
+	if origin != "" {
+		headers.Set("Origin", origin)
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, headers)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+func TestDefaultCheckOriginAllowsAll(t *testing.T) {
+	SetCheckOrigin(nil) // restore default
+	defer SetCheckOrigin(nil)
+
+	if !testUpgradeResult(t, "https://anything.example.com") {
+		t.Error("default checker should allow any origin")
+	}
+}
+
+func TestSetCheckOriginRestrictsUpgrade(t *testing.T) {
+	// Same semantics as the API layer installs: allow an explicit allowlist,
+	// always allow non-browser clients without an Origin header.
+	SetCheckOrigin(func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return true
+		}
+		return origin == "https://app.example.com"
+	})
+	defer SetCheckOrigin(nil)
+
+	if !testUpgradeResult(t, "https://app.example.com") {
+		t.Error("allowed origin should upgrade")
+	}
+	if testUpgradeResult(t, "https://evil.example.com") {
+		t.Error("disallowed origin should not upgrade")
+	}
+	// Non-browser client without an Origin header is allowed.
+	if !testUpgradeResult(t, "") {
+		t.Error("missing origin should upgrade")
+	}
+}


### PR DESCRIPTION
## 问题

所有 API 路由返回 `Access-Control-Allow-Origin: *`，WebSocket upgrader 的 `CheckOrigin` 恒返回 true。任意网站都能跨域读取接口响应（包括密钥等敏感信息）。

## 修复

- `corsMiddleware` 改为基于 `server.cors_origins` 白名单：白名单来源回显具体 origin，非白名单来源不返回 ACAO 头，预检请求显式 403
- localhost/127.0.0.1 开发来源始终放行；无 Origin 头的非浏览器请求不受影响
- WebSocket `CheckOrigin` 与 CORS 共享同一白名单（`ws.SetCheckOrigin` 注入）
- 默认配置 `cors_origins: ["*"]` 改为显式列表 `["https://www.cyberverse.cc"]`（显式配置 `"*"` 仍保留通配行为，向后兼容）
- 新增 6 个单元测试（CORS 放行/拒绝/预检/无 Origin + WS 升级校验）

## 测试

`go test ./internal/api/ ./internal/ws/` 全部通过，`go vet` 干净。