### PR TITLE
fix(webrtc): avoid send-on-closed-channel panic in AV pipeline shutdown

### DIFF
--- a/server/internal/direct/peer.go
+++ b/server/internal/direct/peer.go
@@ -634,12 +634,14 @@ func (p *DirectPeer) currentVideoBitrateKbps() int {
 }
 
 // StopAVPipeline shuts down the AV pipeline goroutines.
+//
+// encodeCh is intentionally NOT closed here: closing it concurrently with a
+// SendAVSegment / WaitAVDrain send would panic ("send on closed channel").
+// Both encoders and senders exit via avPipelineCtx cancellation, and the
+// channel is garbage-collected with the peer.
 func (p *DirectPeer) StopAVPipeline() {
 	if p.avPipelineCancel != nil {
 		p.avPipelineCancel()
-	}
-	if p.encodeCh != nil {
-		close(p.encodeCh)
 	}
 	p.avPipelineWg.Wait()
 }
@@ -648,7 +650,20 @@ func (p *DirectPeer) runEncoder() {
 	defer p.avPipelineWg.Done()
 	defer close(p.publishCh)
 
-	for raw := range p.encodeCh {
+	for {
+		var raw *mediapeer.RawAVSegment
+		var ok bool
+		select {
+		case raw, ok = <-p.encodeCh:
+			if !ok {
+				// encodeCh is not closed by StopAVPipeline by design; this
+				// guard keeps the loop safe if a future caller closes it.
+				return
+			}
+		case <-p.avPipelineCtx.Done():
+			return
+		}
+
 		if p.avPipelineCtx.Err() != nil {
 			return
 		}

--- a/server/internal/livekit/bot.go
+++ b/server/internal/livekit/bot.go
@@ -407,12 +407,14 @@ func (b *Bot) StartAVPipeline(ctx context.Context) {
 }
 
 // StopAVPipeline gracefully shuts down the pipeline and waits for goroutines.
+//
+// encodeCh is intentionally NOT closed here: closing it concurrently with a
+// SendAVSegment / WaitAVDrain send would panic ("send on closed channel").
+// Both encoders and senders exit via avPipelineCtx cancellation, and the
+// channel is garbage-collected with the bot.
 func (b *Bot) StopAVPipeline() {
 	if b.avPipelineCancel != nil {
 		b.avPipelineCancel()
-	}
-	if b.encodeCh != nil {
-		close(b.encodeCh)
 	}
 	b.avPipelineWg.Wait()
 }
@@ -505,7 +507,20 @@ func (b *Bot) runEncoder() {
 	defer b.avPipelineWg.Done()
 	defer close(b.publishCh)
 
-	for raw := range b.encodeCh {
+	for {
+		var raw *RawAVSegment
+		var ok bool
+		select {
+		case raw, ok = <-b.encodeCh:
+			if !ok {
+				// encodeCh is not closed by StopAVPipeline by design; this
+				// guard keeps the loop safe if a future caller closes it.
+				return
+			}
+		case <-b.avPipelineCtx.Done():
+			return
+		}
+
 		if b.avPipelineCtx.Err() != nil {
 			return
 		}


### PR DESCRIPTION
## 问题

`StopAVPipeline` 无条件 `close(encodeCh)`，而 `SendAVSegment`/`WaitAVDrain` 正并发向该 channel 发送。Go 中向已关闭 channel 发送会直接 panic（select 也不提供保护）；重复调用 `StopAVPipeline` 还会 double-close panic。会话超时与显式断开并发时可能触发。

## 修复

- `StopAVPipeline` 不再关闭 `encodeCh`，编码协程统一由 `avPipelineCtx` 取消驱动退出（`runEncoder` 改为 select + ok 检查，兼容未来 close 的兜底）
- 发送方已有的 `ctx.Done()` 分支足以优雅退出，channel 随 peer/bot 生命周期由 GC 回收
- `server/internal/direct/peer.go` 与 `server/internal/livekit/bot.go` 两处相同模式同步修复

## 测试

`go test ./internal/direct/` 通过，`go build ./...` + `go vet` 干净。