### PR TITLE
fix(webrtc): stop closing user audio channel on disconnect

### DIFF
--- a/server/internal/direct/peer.go
+++ b/server/internal/direct/peer.go
@@ -1345,7 +1345,10 @@ func (p *DirectPeer) Disconnect() error {
 	if p.pc != nil {
 		err := p.pc.Close()
 		p.pc = nil
-		close(p.userAudioCh)
+		// userAudioCh is intentionally NOT closed: readUserAudio may still be
+		// sending concurrently (a send on a closed channel panics). It stops
+		// writing once the track closes after pc.Close(), and readers drain
+		// the channel via ok-checks / non-blocking receives.
 		return err
 	}
 	return nil

--- a/server/internal/livekit/bot.go
+++ b/server/internal/livekit/bot.go
@@ -695,8 +695,10 @@ func (b *Bot) Disconnect() error {
 		b.room = nil
 	}
 
-	// Don't close userAudioC here -- readers may still be draining
-	close(b.userAudioC)
+	// Don't close userAudioC here: the PCM remote track's writer goroutine may
+	// still be sending concurrently, and a send on a closed channel panics.
+	// The track stops writing once the room disconnects, and readers drain
+	// the channel via ok-checks / non-blocking receives.
 	log.Printf("Bot disconnected from room %s", b.roomName)
 	return nil
 }


### PR DESCRIPTION
## 问题

`DirectPeer.Disconnect` 关闭 `userAudioCh` 时，`readUserAudio` 协程可能仍在并发发送（select + default 非阻塞发送到已关闭 channel 同样 panic）。livekit `Bot.Disconnect` 中注释明确写着 “Don’t close userAudioC here”，但代码却执行了 `close(b.userAudioC)`——注释与实现矛盾，属遗留缺陷。

## 修复

- 两个 `Disconnect` 均不再显式关闭用户音频 channel
- 写入方随 peer connection / room 关闭自然停止；消费方已使用 `ok` 检查与非阻塞 drain，不依赖 close 终止
- 修正 bot.go 中注释与代码的矛盾

## 测试

`go test ./internal/direct/` 通过，`go build ./...` + `go vet` 干净。