### PR TITLE
fix(docs): restore working star history charts

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -469,8 +469,8 @@ SSH トンネルではなくブラウザからリモートサーバーへ直接�
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#dsd2077/CyberVerse&Date">
-    <img src="https://api.star-history.com/svg?repos=dsd2077/CyberVerse&type=Date" alt="Star History Chart" width="100%"/>
+  <a href="https://star-history.dera.page/#Lynpoint/CyberVerse&Date">
+    <img src="https://star-history.dera.page/svg?repos=Lynpoint/CyberVerse&type=Date" alt="Star History Chart" width="100%"/>
   </a>
 </p>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -470,8 +470,8 @@ SSH 터널이 아니라 브라우저가 원격 서버에 직접 연결되게 하
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#dsd2077/CyberVerse&Date">
-    <img src="https://api.star-history.com/svg?repos=dsd2077/CyberVerse&type=Date" alt="Star History Chart" width="100%"/>
+  <a href="https://star-history.dera.page/#Lynpoint/CyberVerse&Date">
+    <img src="https://star-history.dera.page/svg?repos=Lynpoint/CyberVerse&type=Date" alt="Star History Chart" width="100%"/>
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -477,8 +477,8 @@ Roadmap is maintained in Yuque / Roadmap 已迁移至语雀: [CyberVerse Require
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#dsd2077/CyberVerse&Date">
-    <img src="https://api.star-history.com/svg?repos=dsd2077/CyberVerse&type=Date" alt="Star History Chart" width="100%"/>
+  <a href="https://star-history.dera.page/#Lynpoint/CyberVerse&Date">
+    <img src="https://star-history.dera.page/svg?repos=Lynpoint/CyberVerse&type=Date" alt="Star History Chart" width="100%"/>
   </a>
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -474,8 +474,8 @@ ssh -L 8443:127.0.0.1:8443 user@host -p port
 ## 星标历史
 
 <p align="center">
-  <a href="https://star-history.com/#dsd2077/CyberVerse&Date">
-    <img src="https://api.star-history.com/svg?repos=dsd2077/CyberVerse&type=Date" alt="Star History Chart" width="100%"/>
+  <a href="https://star-history.dera.page/#Lynpoint/CyberVerse&Date">
+    <img src="https://star-history.dera.page/svg?repos=Lynpoint/CyberVerse&type=Date" alt="Star History Chart" width="100%"/>
   </a>
 </p>
 


### PR DESCRIPTION
The current star history charts in the README files are broken, so readers cannot view the project's star history. Update the English and localized README chart references to restore the charts.